### PR TITLE
Remove unnecessary cmdline options and disable more drm drivers

### DIFF
--- a/misc.cbq/misc/cmdline
+++ b/misc.cbq/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 console=ttyMSM0,115200 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 deferred_probe_timeout=30 clk_ignore_unused=1 noresume apparmor=0
+console=tty1 console=ttyMSM0,115200 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes noresume

--- a/misc.cbq/options/options-to-remove-special.cfg
+++ b/misc.cbq/options/options-to-remove-special.cfg
@@ -6,6 +6,7 @@
 # 
 # CONFIG_ACPI is not set
 # CONFIG_ARCH_HAS_ACPI_TABLE_UPGRADE is not set
+# CONFIG_EFI is not set
 #
 # arches which can go most of the time except the one to build for
 #
@@ -58,3 +59,8 @@
 # CONFIG_DRM_STI is not set
 # CONFIG_DRM_VMWGFX is not set
 # CONFIG_DRM_OMAPDRM is not set
+# CONFIG_DRM_VIRTIO_GPU is not set
+# CONFIG_DRM_HISI_HIBMC is not set
+# CONFIG_DRM_HISI_KIRIN is not set
+# CONFIG_DRM_PL111 is not set
+# CONFIG_DRM_TIDSS is not set


### PR DESCRIPTION
Disabled some unused DRM drivers and removed some cmdline options that aren't strictly necessary for normal operation. Tested with kernel 6.6 on Duet3 and everything seems okay. IMO AppArmour shouldn't be disabled by default since not everyone runs Docker on their devices, and we should document these in a separate FAQ document at some point.