### PR TITLE
added missing deps readme.cbq

### DIFF
--- a/readme.cbq
+++ b/readme.cbq
@@ -6,7 +6,7 @@
 # name: stb-cbq - chromebook qualcom
 
 # it looks like for newer kernel versions like v6.5 the following packages have to be
-# installed in order to get the tool compiled well: libelf-dev python3-dev libtraceevent-dev
+# installed in order to get the tool compiled well: libelf-dev python3-dev libtraceevent-dev libpci-dev gettext
 
 cd /compile/source/linux-stable-cbq
 


### PR DESCRIPTION
so yeah docs didn't mention that but u also need to intall ```libpci-dev``` and ```gettext```
```
root@chluk:/compile/source/linux-stable-cbq/tools/power/cpupower# make
  CC       cpupower
/usr/bin/ld: cannot find -lpci: Nie ma takiego pliku ani katalogu
collect2: error: ld returned 1 exit status
make: *** [Makefile:222: cpupower] Błąd 1
```
```
root@chluk:/compile/source/linux-stable-cbq/tools/power/cpupower# make
  CC       cpupower
  MSGFMT   po/de.gmo
make: msgfmt: Nie ma takiego pliku ani katalogu
make: *** [Makefile:236: po/de.gmo] Błąd 127
```
"Nie ma takiego pliku ani katalogu" means "There is no such file or directory"

it's just a minor detail anyway but if we specify what's needed for compilation then yeah it's missing