### PR TITLE
cbe,cbg,cbp,cbq,cbr,cbt: remove default ipv6 disable, add cmdline

### DIFF
--- a/misc.cbe/misc/cmdline
+++ b/misc.cbe/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0

--- a/misc.cbg/misc/cmdline
+++ b/misc.cbg/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 fw_devlink=off noresume apparmor=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0

--- a/misc.cbp/misc/cmdline
+++ b/misc.cbp/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0

--- a/misc.cbq/misc/cmdline
+++ b/misc.cbq/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 console=ttyMSM0,115200 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 deferred_probe_timeout=30 clk_ignore_unused=1 noresume apparmor=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0

--- a/misc.cbr/misc/cmdline
+++ b/misc.cbr/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 gpt root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0
+console=tty1 gpt root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0

--- a/misc.cbt/misc/cmdline
+++ b/misc.cbt/misc/cmdline
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 ipv6.disable=1 noresume fw_devlink=off loglevel=8 drm.debug=0xe apparmor=0 systemd.unified_cgroup_hierarchy=0
+console=tty1 root=PARTUUID=%U/PARTNROFF=3 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 systemd.unified_cgroup_hierarchy=0

--- a/readme.cbg
+++ b/readme.cbg
@@ -52,6 +52,7 @@ cp -v arch/arm64/boot/Image /boot/Image-${kver}
 mkdir -p /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/rockchip/rk3399-gru-*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -65,7 +66,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-cbg/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-cbg/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable/config.cbg /compile/doc/stable/config.cbg.old
 cp -v /compile/source/linux-stable-cbg/.config /compile/doc/stable/config.cbg
 cp -v /compile/source/linux-stable-cbg/.config /compile/doc/stable/config.cbg-${kver}

--- a/readme.cbq
+++ b/readme.cbq
@@ -46,6 +46,7 @@ cp -v arch/arm64/boot/Image /boot/Image-${kver}
 mkdir -p /boot/dtb-${kver}
 cp -v arch/arm64/boot/dts/qcom/sc7180-trogdor*.dtb /boot/dtb-${kver}
 cp -v System.map /boot/System.map-${kver}
+echo "console=tty1 rootwait ro fsck.fix=yes fsck.repair=yes net.ifnames=0 noresume apparmor=0 quiet splash" > /boot/cmdline-${kver}
 # start chromebook special - required: apt-get install liblz4-tool vboot-kernel-utils
 cp arch/arm64/boot/Image Image
 lz4 -f Image Image.lz4
@@ -59,7 +60,7 @@ rm -f Image Image.lz4 cmdline bootloader.bin kernel.itb vmlinux.kpart
 cd /boot
 update-initramfs -c -k ${kver}
 #mkimage -A arm64 -O linux -T ramdisk -a 0x0 -e 0x0 -n initrd.img-${kver} -d initrd.img-${kver} uInitrd-${kver}
-tar cvzf /compile/source/linux-stable-cbq/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
+tar cvzf /compile/source/linux-stable-cbq/${kver}.tar.gz /boot/Image-${kver} /boot/System.map-${kver} /boot/config-${kver} /boot/cmdline-${kver} /boot/dtb-${kver} /boot/initrd.img-${kver} /boot/vmlinux.kpart-${kver} /lib/modules/${kver}
 cp -v /compile/doc/stable/config.cbq /compile/doc/stable/config.cbq.old
 cp -v /compile/source/linux-stable-cbq/.config /compile/doc/stable/config.cbq
 cp -v /compile/source/linux-stable-cbq/.config /compile/doc/stable/config.cbq-${kver}


### PR DESCRIPTION
better no longer turn off ipv6 by default as nowadays its required in some cases and some things like waydroid may run into trouble if ipv6 is disabled

while at the cmdline already: also add the creation and addition of the cmdline-kernel-version file for the chromebook kernels managed by the velvet-tools and also cleanup some most probably no longer required kernel options like fw_devlink=off, deferred_probe_timeout=30, clk_ignore_unused=1 and some drm debugging options